### PR TITLE
Add chip Component

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/designSystem/colors/CraftoLightColors.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/designSystem/colors/CraftoLightColors.kt
@@ -45,7 +45,7 @@ val CraftoLightColors = CraftoColors(
     brand = Brand(
         primary = Color(0xFF5C9EFF),
         secondary = Color(0xFFC1DAFF),
-        tertiary = Color(0xFFF2F27B)
+        tertiary = Color(0xFFF2F7FF)
     ),
     button = Button(
         primary = Color(0xFF5C9EFF),

--- a/composeApp/src/commonMain/kotlin/org/example/project/designSystem/components/chip.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/designSystem/components/chip.kt
@@ -1,0 +1,76 @@
+package org.example.project.designSystem.components
+
+import androidx.compose.foundation.background
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.example.project.designSystem.textStyle.AppTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun Chip(
+    modifier: Modifier = Modifier,
+    text: String,
+    isSelected: Boolean,
+    onChipSelected: (String) -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .background(
+                if (isSelected)
+                    AppTheme.craftoColors.brand.tertiary
+                else
+                    AppTheme.craftoColors.shade.quinary,
+                shape = RoundedCornerShape(AppTheme.craftoRadius.full)
+            )
+            .then(
+                if (isSelected) Modifier.border(
+                    1.dp, AppTheme.craftoColors.brand.secondary, RoundedCornerShape(
+                        AppTheme.craftoRadius.full
+                    )
+                )
+                else Modifier
+            )
+            .clip(RoundedCornerShape(AppTheme.craftoRadius.full))
+            .clickable(
+                enabled = true,
+                onClick = { onChipSelected(text) }
+            )
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            color = if (isSelected) AppTheme.craftoColors.brand.primary else AppTheme.craftoColors.shade.secondary,
+            style = AppTheme.textStyle.label.medium,
+            textAlign = TextAlign.Center,
+        )
+
+    }
+}
+
+@Preview
+@Composable
+private fun ChipPreview() {
+    var selectedChip by remember { mutableStateOf(true) }
+    AppTheme(isDarkTheme =true) {
+        Chip(
+            text = "Label",
+            isSelected = selectedChip,
+        )
+    }
+}


### PR DESCRIPTION
- Add design of chip component to design system
- Edit tertiary brand color in light colors to match the design 

# In Light Theme : 
# Selected : 
<img width="477" height="352" alt="Screenshot 2025-08-31 151127" src="https://github.com/user-attachments/assets/fccf3f2f-f184-4172-b9bd-544fb03d3056" />

# unSelected : 
<img width="496" height="319" alt="Screenshot 2025-08-31 151205" src="https://github.com/user-attachments/assets/8e970a17-5256-4d6a-afe7-bd9940a40d01" />

# In Dark Theme: 
# Selected : 
<img width="473" height="359" alt="Screenshot 2025-08-31 151410" src="https://github.com/user-attachments/assets/52767714-109a-43e1-bff3-4d32073dc856" />
 
# unSelected : 
<img width="421" height="277" alt="Screenshot 2025-08-31 151350" src="https://github.com/user-attachments/assets/ad61481a-c04f-48a7-bd32-34b9b60e5a2a" />

